### PR TITLE
chore: configure daily dependency updates for maven and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,26 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
+
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "maven"
+    directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    labels:
+      - "dependencies"
+      - "java"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    labels:
+      - "dependencies"
+      - "github actions"


### PR DESCRIPTION
## Purpose of the pull request

configure daily dependency updates for maven and github actions

## What's changed?

- Set up daily schedule for both maven and github-actions ecosystems
- Limit open pull requests to 5
- Ignore **major** and **minor** version updates for all dependencies
- Add appropriate labels for java and github actions dependencies
- Target main branch for all dependency updates

## Checklist

- [x] I have read the [Contributor Guide](https://fast-excel.github.io/fastexcel/community/contribution).
- [x] I have written the necessary doc or comment.
- [ ] I have added the necessary unit tests and all cases have passed.
